### PR TITLE
Add CommandRegistry with `help` and `cd` handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(BINARY ${CMAKE_PROJECT_NAME})
 
-set(SOURCES commandline.cpp exec.cpp)
+set(SOURCES commandline.cpp commandregistry.cpp exec.cpp)
 
 add_library(${BINARY}_lib STATIC ${SOURCES})
 target_include_directories(${BINARY}_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/commandregistry.cpp
+++ b/src/commandregistry.cpp
@@ -1,0 +1,55 @@
+#include "commandregistry.h"
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <unistd.h>
+
+namespace evsh {
+
+namespace {
+
+    int cd(const CommandLine& commandLine)
+    {
+        if (commandLine.size() < 2) {
+            std::cerr << "cd: No path specified" << std::endl;
+            return EXIT_FAILURE;
+        }
+        const auto rc = chdir(commandLine[1].data());
+        if (rc) {
+            std::cerr << "cd: " << strerror(errno) << std::endl;
+        }
+        return rc;
+    }
+
+    int help(const CommandLine&)
+    {
+        std::cout << "Help for evsh internal commands\n\n"
+                     "cd dir    - change current directory\n"
+                     "help      - print this help\n"
+                  << std::endl;
+        return EXIT_SUCCESS;
+    }
+}
+
+void CommandRegistry::add(const std::string_view name, Command command) {
+    d_registry[std::string{name}] = command;
+}
+
+std::optional<int> CommandRegistry::tryExec(const CommandLine& commandLine) const
+{
+    const auto search = d_registry.find(commandLine[0]);
+    if (search != d_registry.end()) {
+        return search->second(commandLine);
+    }
+    return {};
+}
+
+CommandRegistry defaultCommandRegistry()
+{
+    CommandRegistry cr;
+    cr.add("cd", cd);
+    cr.add("help", help);
+
+    return cr;
+}
+}

--- a/src/commandregistry.h
+++ b/src/commandregistry.h
@@ -1,0 +1,30 @@
+#pragma onec
+#include "commandline.h"
+#include <functional>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace evsh {
+
+// A registry of internal commands which can be executed
+class CommandRegistry {
+public:
+    // An executable command
+    using Command = std::function<int(const CommandLine&)>;
+
+    // Add a command to the registry
+    void add(const std::string_view name, Command command);
+
+    // Attempt to execute the command if present in the registry.
+    // Returns the return code of the executed command if present.
+    // Otherwise returns an empty optionable.
+    std::optional<int> tryExec(const CommandLine& commandLine) const;
+
+private:
+    std::map<std::string, Command> d_registry;
+};
+
+// Instantiates a CommandRegistry and preload the built-in commands
+CommandRegistry defaultCommandRegistry();
+}

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1,6 +1,7 @@
 #include "exec.h"
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <sys/types.h>
@@ -23,17 +24,8 @@ int exec(const CommandLine& commandLine)
         return -1;
     } else { // Child
         C_CommandLine c_cmdLine{ commandLine };
-        const auto rc = execvp(c_cmdLine.data()[0], const_cast<char* const*>(c_cmdLine.data()));
-        std::string error{ commandLine[0] };
-        switch (errno) {
-        case EACCES:
-            error += ": permission denied";
-            break;
-        default:
-            error += ": command not found";
-            break;
-        }
-        std::cerr << error << std::endl;
+        execvp(c_cmdLine.data()[0], const_cast<char* const*>(c_cmdLine.data()));
+        std::cerr << commandLine[0] << ": " << strerror(errno) << std::endl;
         std::exit(EXIT_FAILURE);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "commandline.h"
+#include "commandregistry.h"
 #include "exec.h"
 #include <csignal>
 #include <iostream>
@@ -8,6 +9,7 @@ using namespace evsh;
 int main(int argc, char* argv[])
 {
     std::signal(SIGINT, SIG_IGN);
+    const auto commandRegistry = defaultCommandRegistry();
     for (;;) {
         std::string line;
         std::cout << "$ ";
@@ -15,7 +17,15 @@ int main(int argc, char* argv[])
             break;
         }
         const auto commandLine = parse(line);
-        auto rc = exec(commandLine);
+        int rc;
+        if (!commandLine.empty()) {
+            const auto res = commandRegistry.tryExec(commandLine);
+            if (res.has_value()) {
+                rc = res.value();
+            } else {
+                rc = exec(commandLine);
+            }
+        }
     }
     return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ include(GoogleTest)
 
 set(BINARY ${CMAKE_PROJECT_NAME})
 
-add_executable(${BINARY}.u.t test_commandline.u.t.cpp test_exec.u.t.cpp)
+add_executable(${BINARY}.u.t test_commandline.u.t.cpp test_commandregistry.u.t.cpp test_exec.u.t.cpp)
 target_link_libraries(${BINARY}.u.t ${BINARY}_lib gtest_main gmock gtest pthread)
 
 gtest_discover_tests(${BINARY}.u.t

--- a/test/test_commandregistry.u.t.cpp
+++ b/test/test_commandregistry.u.t.cpp
@@ -1,0 +1,30 @@
+#include "commandline.h"
+#include "commandregistry.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace evsh;
+
+TEST(TestCommandRegistry, AddAndTryExec)
+{
+    CommandRegistry cr;
+    cr.add("test", [](auto) { return 42; });
+    const auto res = cr.tryExec({"test"});
+    EXPECT_THAT(res, Optional(42));
+}
+
+TEST(TestCommandRegistry, TryExecMissing)
+{
+    CommandRegistry cr;
+    const auto res = cr.tryExec({"test"});
+    EXPECT_THAT(res.has_value(), IsFalse());
+}
+
+TEST(TestCommandRegistry, defaultCommandRegistry)
+{
+    const auto cr = defaultCommandRegistry();
+    auto res = cr.tryExec({"help"});
+    EXPECT_THAT(res, Optional(0));
+}
+

--- a/test/test_exec.u.t.cpp
+++ b/test/test_exec.u.t.cpp
@@ -9,11 +9,6 @@
 using namespace ::testing;
 using namespace evsh;
 
-TEST(TestExec, EmptyCommandLine)
-{
-    EXPECT_THAT(exec({}), Eq(0));
-}
-
 TEST(TestExec, InvalidCommand)
 {
     EXPECT_THAT(exec({"./nonexistent_command"}), Eq(EXIT_FAILURE));


### PR DESCRIPTION
- Added CommandRegistry class for managing internal commands
- Added `cd` and `help` commands
- Integrated internal commands into execution step
- Removed unnecessary empty command handling in exec