### PR TITLE
Support for simple fd redirects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: WebKit

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(BINARY ${CMAKE_PROJECT_NAME})
 
-set(SOURCES commandline.cpp commandregistry.cpp exec.cpp)
+set(SOURCES commandline.cpp commandregistry.cpp exec.cpp parse.cpp)
 
 add_library(${BINARY}_lib STATIC ${SOURCES})
 target_include_directories(${BINARY}_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -1,14 +1,12 @@
 #include "commandline.h"
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 
 using namespace std;
 
 namespace evsh {
 namespace {
 
-    const char* const* to_char_array(const CommandLine& input)
+    const char* const* to_char_array(const CommandLine::Arguments& input)
     {
         char const** const output = new char const* [input.size() + 1] { nullptr };
         std::transform(input.begin(), input.end(), output,
@@ -17,26 +15,15 @@ namespace {
     }
 }
 
-CommandLine parse(string_view line)
-{
-    CommandLine out;
-    auto str = std::string{};
-    auto iss = std::istringstream{ line.data() };
-    while (iss >> quoted(str)) {
-        out.push_back(std::move(str));
-    }
-    return out;
-}
-
-C_CommandLine::C_CommandLine(const CommandLine& commandLine)
-    : d_data(to_char_array(commandLine))
+C_CommandLineArguments::C_CommandLineArguments(const CommandLine::Arguments& arguments)
+    : d_data(to_char_array(arguments))
 {
 }
-C_CommandLine::~C_CommandLine()
+C_CommandLineArguments::~C_CommandLineArguments()
 {
     delete d_data;
 }
-const char* const* C_CommandLine::data() const
+const char* const* C_CommandLineArguments::data() const
 {
     return d_data;
 }

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -1,21 +1,40 @@
 #pragma once
+#include <array>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
+
 namespace evsh {
 
-using CommandLine = std::vector<std::string>;
+struct CommandLine {
+    // Types
+    using Arguments = std::vector<std::string>;
+    struct EmptyRedirect {
+    };
+    struct FileRedirect {
+        std::string filename;
+        bool append;
+    };
+    struct RemapRedirect {
+        int fd;
+    };
+    using Redirect = std::variant<EmptyRedirect, FileRedirect, RemapRedirect>;
+    using Redirects = std::array<Redirect, 3>;
+
+    // Data
+    Arguments arguments;
+    Redirects redirects;
+};
 
 // Temporary object that represents arguments
-struct C_CommandLine {
+struct C_CommandLineArguments {
     const char* const* data() const;
-    C_CommandLine(const CommandLine& commandLine);
-    ~C_CommandLine();
+    C_CommandLineArguments(const CommandLine::Arguments& arguments);
+    ~C_CommandLineArguments();
 
 private:
     const char* const* d_data;
 };
 
-// Parse a text line into a CommandLine
-CommandLine parse(std::string_view line);
 } // namespace evsh

--- a/src/commandregistry.cpp
+++ b/src/commandregistry.cpp
@@ -10,11 +10,11 @@ namespace {
 
     int cd(const CommandLine& commandLine)
     {
-        if (commandLine.size() < 2) {
+        if (commandLine.arguments.size() < 2) {
             std::cerr << "cd: No path specified" << std::endl;
             return EXIT_FAILURE;
         }
-        const auto rc = chdir(commandLine[1].data());
+        const auto rc = chdir(commandLine.arguments[1].data());
         if (rc) {
             std::cerr << "cd: " << strerror(errno) << std::endl;
         }
@@ -37,7 +37,7 @@ void CommandRegistry::add(const std::string_view name, Command command) {
 
 std::optional<int> CommandRegistry::tryExec(const CommandLine& commandLine) const
 {
-    const auto search = d_registry.find(commandLine[0]);
+    const auto search = d_registry.find(commandLine.arguments[0]);
     if (search != d_registry.end()) {
         return search->second(commandLine);
     }

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -2,16 +2,81 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <type_traits>
 #include <unistd.h>
+#include <variant>
 
 namespace evsh {
+
+namespace {
+
+    bool configure_redirects(const CommandLine::Redirects& redirects)
+    {
+        int newFds[3] = { -1, -1, -1 };
+
+        if (!std::visit([&newFds](auto&& redirect) {
+                using T = std::decay_t<decltype(redirect)>;
+                if constexpr (std::is_same_v<T, CommandLine::FileRedirect>) {
+                    const auto fd = open(redirect.filename.c_str(), O_RDONLY);
+                    if (fd == -1) {
+                        std::cerr << redirect.filename << ": " << strerror(errno) << std::endl;
+                        return false;
+                    }
+                    newFds[0] = fd;
+                }
+                return true;
+            },
+                redirects[0])) {
+            return false;
+        }
+
+        for (auto i : { 1, 2 }) {
+            if (!std::visit([&newFds, i](auto&& redirect) {
+                    using T = std::decay_t<decltype(redirect)>;
+                    if constexpr (std::is_same_v<T, CommandLine::FileRedirect>) {
+                        const auto fd = open(redirect.filename.c_str(),
+                            O_CREAT | O_WRONLY | (redirect.append ? O_APPEND : O_TRUNC),
+                            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+                        if (fd == -1) {
+                            std::cerr << redirect.filename << ": " << strerror(errno) << std::endl;
+                            return false;
+                        }
+                        newFds[i] = fd;
+                    } else if constexpr (std::is_same_v<T, CommandLine::RemapRedirect>) {
+                        newFds[i] = redirect.fd;
+                    }
+                    return true;
+                },
+                    redirects[i])) {
+                return false;
+            }
+        }
+
+        for (auto i = 0; i < 3; ++i) {
+            if (newFds[i] != -1) {
+                if (dup2(newFds[i], i) == -1) {
+                    std::cerr << strerror(errno) << std::endl;
+                    return false;
+                }
+                if (newFds[i] > 2) { // only close hanging fds other than stdin/out/err
+                    close(newFds[i]);
+                }
+            }
+        }
+        return true;
+    }
+
+}
+
 int exec(const CommandLine& commandLine)
 {
-    if (commandLine.empty()) {
+    if (commandLine.arguments.empty()) {
         return 0;
     }
     const auto pid = fork();
@@ -23,9 +88,12 @@ int exec(const CommandLine& commandLine)
         }
         return -1;
     } else { // Child
-        C_CommandLine c_cmdLine{ commandLine };
-        execvp(c_cmdLine.data()[0], const_cast<char* const*>(c_cmdLine.data()));
-        std::cerr << commandLine[0] << ": " << strerror(errno) << std::endl;
+        C_CommandLineArguments c_args { commandLine.arguments };
+        if (!configure_redirects(commandLine.redirects)) {
+            std::exit(EXIT_FAILURE);
+        }
+        execvp(c_args.data()[0], const_cast<char* const*>(c_args.data()));
+        std::cerr << commandLine.arguments[0] << ": " << strerror(errno) << std::endl;
         std::exit(EXIT_FAILURE);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
-#include "commandline.h"
 #include "commandregistry.h"
 #include "exec.h"
+#include "parse.h"
 #include <csignal>
 #include <iostream>
 
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
         }
         const auto commandLine = parse(line);
         int rc;
-        if (!commandLine.empty()) {
+        if (!commandLine.arguments.empty()) {
             const auto res = commandRegistry.tryExec(commandLine);
             if (res.has_value()) {
                 rc = res.value();

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -1,0 +1,82 @@
+#include "parse.h"
+#include <bitset>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+
+namespace evsh {
+namespace {
+
+};
+
+void applyRedirects(CommandLine::Redirects& existing, const CommandLine::Redirects& next)
+{
+    for (auto i = 0; i < existing.size(); ++i) {
+        if (!std::holds_alternative<CommandLine::EmptyRedirect>(next[i])) {
+            existing[i] = next[i];
+        }
+    }
+}
+
+CommandLine parse(string_view line)
+{
+    CommandLine out;
+    auto str = std::string {};
+    auto iss = std::istringstream { line.data() };
+    while (iss >> quoted(str)) {
+        const auto redirects = tryParseRedirect(str);
+        if (redirects.has_value()) {
+            applyRedirects(out.redirects, *redirects);
+        } else {
+            out.arguments.push_back(std::move(str));
+        }
+    }
+    return out;
+}
+
+std::optional<CommandLine::Redirects> tryParseRedirect(std::string_view argument)
+{
+    CommandLine::Redirects redirects;
+    CommandLine::Redirect* destination;
+    int offset;
+    bool append {};
+
+    if (argument.find("<") == 0) {
+        destination = &redirects[0];
+        offset = 1;
+    } else if (argument.find(">") == 0) {
+        destination = &redirects[1];
+        offset = 1;
+    } else if (argument.find("1>") == 0) {
+        destination = &redirects[1];
+        offset = 2;
+    } else if (argument.find("2>") == 0) {
+        destination = &redirects[2];
+        offset = 2;
+    } else if (argument.find("&>") == 0) {
+        destination = &redirects[1];
+        redirects[2] = CommandLine::RemapRedirect { 1 };
+        offset = 2;
+    } else {
+        return {};
+    }
+
+    if (argument[offset] == '>') {
+        append = true;
+        ++offset;
+    }
+
+    argument = argument.substr(offset);
+    if (argument == "&1") {
+        *destination = CommandLine::RemapRedirect { 1 };
+    } else if (argument == "&2") {
+        *destination = CommandLine::RemapRedirect { 2 };
+    } else {
+        *destination = CommandLine::FileRedirect { string { argument }, append };
+    }
+
+    return redirects;
+}
+
+}

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "commandline.h"
+
+#include <optional>
+#include <string_view>
+
+namespace evsh {
+
+// Incrementally apply redirects
+void applyRedirects(CommandLine::Redirects& existing, const CommandLine::Redirects& next);
+
+// Parse a text line into a CommandLine
+CommandLine parse(std::string_view line);
+
+// Try parse a single argument into a redirect statement
+std::optional<CommandLine::Redirects> tryParseRedirect(std::string_view argument);
+
+} // namespace evsh

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ include(GoogleTest)
 
 set(BINARY ${CMAKE_PROJECT_NAME})
 
-add_executable(${BINARY}.u.t test_commandline.u.t.cpp test_commandregistry.u.t.cpp test_exec.u.t.cpp)
+add_executable(${BINARY}.u.t test_commandline.u.t.cpp test_commandregistry.u.t.cpp test_exec.u.t.cpp test_parse.u.t.cpp)
 target_link_libraries(${BINARY}.u.t ${BINARY}_lib gtest_main gmock gtest pthread)
 
 gtest_discover_tests(${BINARY}.u.t

--- a/test/test_commandline.u.t.cpp
+++ b/test/test_commandline.u.t.cpp
@@ -5,44 +5,19 @@
 using namespace ::testing;
 using namespace evsh;
 
-TEST(TestCommandLine, ParseEmpty)
+TEST(Test_C_CommandLineArguments, CommandOnly)
 {
-    EXPECT_THAT(parse(""), Eq(CommandLine{}));
+    const CommandLine cmdLine { { "command" } };
+    const C_CommandLineArguments c_args { cmdLine.arguments };
+    EXPECT_THAT(c_args.data()[0], Eq(cmdLine.arguments[0].data()));
+    EXPECT_THAT(c_args.data()[1], IsNull());
 }
 
-TEST(TestCommandLine, ParseCommandOnly)
+TEST(Test_C_CommandLineArguments, CommandWithArgs)
 {
-    EXPECT_THAT(parse("command"), Eq(CommandLine{ "command" }));
-}
-
-TEST(TestCommandLine, ParseCommandWithOneArg)
-{
-    EXPECT_THAT(parse("command arg"), Eq(CommandLine{ "command", "arg" }));
-}
-
-TEST(TestCommandLine, ParseCommandWithManyArgs)
-{
-    EXPECT_THAT(parse("command arg1 arg2"), Eq(CommandLine{ "command", "arg1", "arg2" }));
-}
-
-TEST(TestCommandLine, ParseCommandWithQuotedArg)
-{
-    EXPECT_THAT(parse("command \"quoted arg\""), Eq(CommandLine{ "command", "quoted arg" }));
-}
-
-TEST(TestC_CommandLine, CommandOnly)
-{
-    const CommandLine cmdLine{ "command" };
-    const C_CommandLine c_cmdLine{ cmdLine };
-    EXPECT_THAT(c_cmdLine.data()[0], Eq(cmdLine[0].data()));
-    EXPECT_THAT(c_cmdLine.data()[1], IsNull());
-}
-
-TEST(TestC_CommandLine, CommandWithArgs)
-{
-    const CommandLine cmdLine{ "command", { "arg" } };
-    const C_CommandLine c_cmdLine{ cmdLine };
-    EXPECT_THAT(c_cmdLine.data()[0], Eq(cmdLine[0].data()));
-    EXPECT_THAT(c_cmdLine.data()[1], Eq(cmdLine[1].data()));
-    EXPECT_THAT(c_cmdLine.data()[2], IsNull());
+    const CommandLine cmdLine { { "command", "arg" } };
+    const C_CommandLineArguments c_args { cmdLine.arguments };
+    EXPECT_THAT(c_args.data()[0], Eq(cmdLine.arguments[0].data()));
+    EXPECT_THAT(c_args.data()[1], Eq(cmdLine.arguments[1].data()));
+    EXPECT_THAT(c_args.data()[2], IsNull());
 }

--- a/test/test_commandregistry.u.t.cpp
+++ b/test/test_commandregistry.u.t.cpp
@@ -10,21 +10,20 @@ TEST(TestCommandRegistry, AddAndTryExec)
 {
     CommandRegistry cr;
     cr.add("test", [](auto) { return 42; });
-    const auto res = cr.tryExec({"test"});
+    const auto res = cr.tryExec({{ "test" }});
     EXPECT_THAT(res, Optional(42));
 }
 
 TEST(TestCommandRegistry, TryExecMissing)
 {
     CommandRegistry cr;
-    const auto res = cr.tryExec({"test"});
+    const auto res = cr.tryExec({{ "test" }});
     EXPECT_THAT(res.has_value(), IsFalse());
 }
 
 TEST(TestCommandRegistry, defaultCommandRegistry)
 {
     const auto cr = defaultCommandRegistry();
-    auto res = cr.tryExec({"help"});
+    auto res = cr.tryExec({{ "help" }});
     EXPECT_THAT(res, Optional(0));
 }
-

--- a/test/test_exec.u.t.cpp
+++ b/test/test_exec.u.t.cpp
@@ -1,20 +1,33 @@
 #include "commandline.h"
 #include "exec.h"
+#include "parse.h"
+#include <cstdlib>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <unistd.h>
-#include <cstdlib>
 
 using namespace ::testing;
 using namespace evsh;
 
 TEST(TestExec, InvalidCommand)
 {
-    EXPECT_THAT(exec({"./nonexistent_command"}), Eq(EXIT_FAILURE));
+    EXPECT_THAT(exec({ { "./nonexistent_command" } }), Eq(EXIT_FAILURE));
 }
 
 TEST(TestExec, ValidCommand)
 {
-    EXPECT_THAT(exec({"sh", "-c", "exit 42"}), Eq(42));
+    EXPECT_THAT(exec({ { "sh", "-c", "exit 42" } }), Eq(42));
+}
+
+TEST(TestExecRedirect, BasicToFileFromFileRedirectTest)
+{
+    exec(parse("echo return 42 >TestExecRedirect.BasicToFileFromFileRedirectTest"));
+    EXPECT_THAT(exec(parse("sh <TestExecRedirect.BasicToFileFromFileRedirectTest")), Eq(42));
+}
+
+TEST(TestExecRedirect, RedirectBothOutToFile)
+{
+    exec(parse("sh -c \"echo 1; echo 2 1>&2\" &>TestExecRedirect.RedirectBothOutToFile"));
+    EXPECT_THAT(exec(parse("sh -c \"return $(wc -l TestExecRedirect.RedirectBothOutToFile)\"")), Eq(2));
 }

--- a/test/test_parse.u.t.cpp
+++ b/test/test_parse.u.t.cpp
@@ -1,0 +1,168 @@
+#include "parse.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tuple>
+#include <variant>
+
+using namespace ::testing;
+using namespace evsh;
+
+MATCHER_P(IsRedirect, other, "")
+{
+    if (arg.index() != other.index()) {
+        return false;
+    }
+    if (std::holds_alternative<CommandLine::EmptyRedirect>(arg)) {
+        return true;
+    } else if (std::holds_alternative<CommandLine::FileRedirect>(arg)) {
+        return std::get<CommandLine::FileRedirect>(arg).filename == std::get<CommandLine::FileRedirect>(other).filename && std::get<CommandLine::FileRedirect>(arg).append == std::get<CommandLine::FileRedirect>(other).append;
+    } else if (std::holds_alternative<CommandLine::RemapRedirect>(arg)) {
+        return std::get<CommandLine::RemapRedirect>(arg).fd == std::get<CommandLine::RemapRedirect>(other).fd;
+    }
+    return false;
+}
+
+TEST(TestParse, ParseEmpty)
+{
+    EXPECT_THAT(parse("").arguments, Eq(CommandLine {}.arguments));
+}
+
+TEST(TestParse, ParseCommandOnly)
+{
+    EXPECT_THAT(parse("command").arguments, Eq(CommandLine { { "command" } }.arguments));
+}
+
+TEST(TestParse, ParseCommandWithOneArg)
+{
+    EXPECT_THAT(parse("command arg").arguments, Eq(CommandLine { { "command", "arg" } }.arguments));
+}
+
+TEST(TestParse, ParseCommandWithManyArgs)
+{
+    EXPECT_THAT(parse("command arg1 arg2").arguments, Eq(CommandLine { { "command", "arg1", "arg2" } }.arguments));
+}
+
+TEST(TestParse, ParseCommandWithQuotedArg)
+{
+    EXPECT_THAT(parse("command \"quoted arg\"").arguments, Eq(CommandLine { { "command", "quoted arg" } }.arguments));
+}
+
+TEST(TestParse, ParseCommandWithRedirects)
+{
+    const auto cmdLine = parse("command >file");
+    EXPECT_THAT(cmdLine.arguments, Eq(CommandLine::Arguments { "command" }));
+    EXPECT_THAT(cmdLine.redirects[1], IsRedirect(CommandLine::Redirect { CommandLine::FileRedirect { "file" } }));
+}
+
+TEST(TestApplyRedirects, ApplyIncremental)
+{
+    CommandLine::Redirects existing {
+        CommandLine::EmptyRedirect {},
+        CommandLine::FileRedirect { "2" },
+        CommandLine::EmptyRedirect {}
+    };
+    const CommandLine::Redirects next {
+        CommandLine::FileRedirect { "1" },
+        CommandLine::EmptyRedirect {},
+        CommandLine::FileRedirect { "3" }
+    };
+    applyRedirects(existing, next);
+    EXPECT_THAT(existing[0], IsRedirect(CommandLine::Redirect { CommandLine::FileRedirect { "1" } }));
+    EXPECT_THAT(existing[1], IsRedirect(CommandLine::Redirect { CommandLine::FileRedirect { "2" } }));
+    EXPECT_THAT(existing[2], IsRedirect(CommandLine::Redirect { CommandLine::FileRedirect { "3" } }));
+}
+
+TEST(TestTryParseRedirect, NonRedirectCase)
+{
+    const auto redirects = tryParseRedirect("foo");
+    EXPECT_THAT(redirects.has_value(), IsFalse());
+}
+
+struct RedirectParseTestParams {
+    const char* param;
+    CommandLine::Redirects redirects;
+    const char* message;
+};
+std::ostream& operator<<(std::ostream& stream, const RedirectParseTestParams& obj)
+{
+    return stream << obj.message << ": " << obj.param;
+}
+
+class TestWithRedirectParseTestParams : public testing::TestWithParam<RedirectParseTestParams> {
+};
+
+TEST_P(TestWithRedirectParseTestParams, TryParseRedirect)
+{
+    const auto redirects = tryParseRedirect(GetParam().param);
+    EXPECT_THAT(redirects.has_value(), IsTrue());
+    for (auto i = 0; i < redirects->size(); ++i) {
+        EXPECT_THAT((*redirects)[i], IsRedirect(GetParam().redirects[i])) << "Incorrect Redirect: " << i;
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(,
+    TestWithRedirectParseTestParams,
+    testing::Values(
+        RedirectParseTestParams {
+            ">file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file" },
+                CommandLine::EmptyRedirect {} },
+            "stdout to file" },
+        RedirectParseTestParams {
+            "2>file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file" } },
+            "stderr to file" },
+        RedirectParseTestParams {
+            "&>file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file" },
+                CommandLine::RemapRedirect { 1 } },
+            "both stdout and stderr to file" },
+        RedirectParseTestParams {
+            ">>file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file", true },
+                CommandLine::EmptyRedirect {} },
+            "stdout append file" },
+        RedirectParseTestParams {
+            "2>>file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file", true } },
+            "stderr append file" },
+        RedirectParseTestParams {
+            "&>>file",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::FileRedirect { "file", true },
+                CommandLine::RemapRedirect { 1 } },
+            "both stdout and stderr append file" },
+        RedirectParseTestParams {
+            "<file",
+            CommandLine::Redirects {
+                CommandLine::FileRedirect { "file" },
+                CommandLine::EmptyRedirect {},
+                CommandLine::EmptyRedirect {} },
+            "stdin from file" },
+        RedirectParseTestParams {
+            "1>&2",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::RemapRedirect { 2 },
+                CommandLine::EmptyRedirect {} },
+            "stdout to stderr" },
+        RedirectParseTestParams {
+            "2>&1",
+            CommandLine::Redirects {
+                CommandLine::EmptyRedirect {},
+                CommandLine::EmptyRedirect {},
+                CommandLine::RemapRedirect { 1 } },
+            "stderr to stdout" }));


### PR DESCRIPTION
- Extracted parse logic from `commandline` to `parse`
- Extended CommandLine to support Redirects
- Added parser for Redirects
- Added tests for Redirects Parser
- Added redirect handling in `exec.cpp`
- Added some simple tests for exec and redirects
- Added .clang-format file