### PR TITLE
Support killing child process on interrupt

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -71,7 +71,7 @@ namespace {
         }
         return true;
     }
-
+    pid_t childPid = 0;
 }
 
 int exec(const CommandLine& commandLine)
@@ -79,10 +79,11 @@ int exec(const CommandLine& commandLine)
     if (commandLine.arguments.empty()) {
         return 0;
     }
-    const auto pid = fork();
-    if (pid) { // Parent
+    childPid = fork();
+    if (childPid) { // Parent
         int wstatus;
         wait(&wstatus);
+        childPid = 0;
         if (WIFEXITED(wstatus)) {
             return WEXITSTATUS(wstatus);
         }
@@ -96,5 +97,13 @@ int exec(const CommandLine& commandLine)
         std::cerr << commandLine.arguments[0] << ": " << strerror(errno) << std::endl;
         std::exit(EXIT_FAILURE);
     }
+}
+
+int kill()
+{
+    if (childPid) {
+        return ::kill(childPid, SIGTERM);
+    }
+    return 0;
 }
 }

--- a/src/exec.h
+++ b/src/exec.h
@@ -7,4 +7,7 @@ namespace evsh {
 // Return 0 if no command (empty commandLine) passed.
 // Return -1 and log to stderr if failed to execute the command.
 int exec(const CommandLine& commandLine);
+
+// Kills the current child process, if running.
+int kill();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,9 @@ using namespace evsh;
 
 int main(int argc, char* argv[])
 {
-    std::signal(SIGINT, SIG_IGN);
+    std::signal(SIGINT, [](auto signum) {
+        kill();
+    });
     const auto commandRegistry = defaultCommandRegistry();
     for (;;) {
         std::string line;


### PR DESCRIPTION
Previously only a SIGINT is propagated to child, which works only as
long as the child process actually responds to SIGINT, which `sleep`
does not. A SIGTERM is now sent to the child process if running.